### PR TITLE
 No need to call datetime.replace for datetime.now(timezone.utc)

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -13,7 +13,7 @@ import scroll
 
 
 def currentTimestamp():
-    return datetime.datetime.now(timezone.utc).replace(tzinfo=timezone.utc).timestamp()
+    return datetime.datetime.now(timezone.utc).timestamp()
 
 
 def getSearches(JSONPath):


### PR DESCRIPTION
datetime.now(timezone.utc) already has the timezone set to UTC, so calling replace(tzinfo=timezone.utc) is redundant